### PR TITLE
Missing parameters lead to a 404

### DIFF
--- a/routes/login.rb
+++ b/routes/login.rb
@@ -9,7 +9,10 @@ LoginRoutes.define do
     })
   end
 
-  on post, param('email'), param('password') do |email, password|
+  on post do
+    email = req.params['email']
+    password = req.params['password']
+
     if login(User, email, password)
       res.redirect '/'
     else

--- a/routes/register.rb
+++ b/routes/register.rb
@@ -14,8 +14,8 @@ RegisterRoutes.define do
     registration = RegisterValidation.new(req.params)
 
     if registration.valid?
-      User.create(registration.slice(:email, :nickname, :password))
-      login(User, registration.email, registration.password)
+      user = User.create(registration.slice(:email, :nickname, :password))
+      authenticate(user)
       res.redirect '/'
     else
       render('register', {

--- a/routes/register.rb
+++ b/routes/register.rb
@@ -14,19 +14,15 @@ RegisterRoutes.define do
     registration = RegisterValidation.new(req.params)
 
     if registration.valid?
-      begin
-        User.create(registration.slice(:email, :nickname, :password))
-        login(User, registration.email, registration.password)
-        res.redirect '/'
-      rescue Ohm::UniqueIndexViolation
-        registration.errors[:email].push(:email_already_taken)
-      end
+      User.create(registration.slice(:email, :nickname, :password))
+      login(User, registration.email, registration.password)
+      res.redirect '/'
+    else
+      render('register', {
+        errors: registration.errors,
+        email: registration.email,
+        nickname: registration.nickname
+      })
     end
-
-    render('register', {
-      errors: registration.errors,
-      email: registration.email,
-      nickname: registration.nickname
-    })
   end
 end

--- a/routes/register.rb
+++ b/routes/register.rb
@@ -10,13 +10,8 @@ RegisterRoutes.define do
     })
   end
 
-  on post, param('email'), param('nickname'), param('password'), param('password_confirmation') do |email, nickname, password, password_confirmation|
-    registration = RegisterValidation.new(
-      email: email,
-      nickname: nickname,
-      password: password,
-      password_confirmation: password_confirmation
-    )
+  on post do
+    registration = RegisterValidation.new(req.params)
 
     if registration.valid?
       begin
@@ -30,8 +25,8 @@ RegisterRoutes.define do
 
     render('register', {
       errors: registration.errors,
-      email: email,
-      nickname: nickname
+      email: registration.email,
+      nickname: registration.nickname
     })
   end
 end

--- a/translations/de.yml
+++ b/translations/de.yml
@@ -25,6 +25,7 @@ login:
   submit: "Anmelden"
   registration: "Registrieren"
 errors:
+  not_present: "Darf nicht leergelassen werden."
   not_email: "Keine gültige Email Adresse."
   not_confirmed: "Passwörter stimmen nicht überein."
   too_short: "Passwort ist zu kurz (mindestens 5 Zeichen)."

--- a/translations/de.yml
+++ b/translations/de.yml
@@ -29,5 +29,5 @@ errors:
   not_email: "Keine gültige Email Adresse."
   not_confirmed: "Passwörter stimmen nicht überein."
   too_short: "Passwort ist zu kurz (mindestens 5 Zeichen)."
-  email_already_taken: "Email Adresse ist schon belegt."
+  not_unique: "Leider schon belegt."
   wrong_username_or_password: "Benutzername oder Passwort falsch"

--- a/validations/register.rb
+++ b/validations/register.rb
@@ -5,8 +5,18 @@ class RegisterValidation < Scrivener
   attr_accessor :password_confirmation
 
   def validate
-    assert_email(:email)
-    assert_minimum_length(:password, 5)
-    assert_confirmation(:password)
+    if assert_present(:email)
+      assert_email(:email)
+    end
+
+    assert_present(:nickname)
+
+    if assert_present(:password)
+      assert_minimum_length(:password, 5)
+    end
+
+    if assert_present(:password_confirmation)
+      assert_confirmation(:password)
+    end
   end
 end

--- a/validations/register.rb
+++ b/validations/register.rb
@@ -7,6 +7,7 @@ class RegisterValidation < Scrivener
   def validate
     if assert_present(:email)
       assert_email(:email)
+      assert_unique(:email, :User)
     end
 
     assert_present(:nickname)


### PR DESCRIPTION
When you commit a form with a missing field, you will get a 404. What we want instead is that this leads to a validation error.

*This is due to the way we handle parameters.*